### PR TITLE
Allow file-like objects when saving and loading

### DIFF
--- a/coqpit/coqpit.py
+++ b/coqpit/coqpit.py
@@ -1,4 +1,5 @@
 import argparse
+import contextlib
 import functools
 import json
 import operator
@@ -8,7 +9,7 @@ from dataclasses import MISSING as _MISSING
 from dataclasses import Field, asdict, dataclass, fields, is_dataclass, replace
 from pathlib import Path
 from pprint import pprint
-from typing import Any, Dict, Generic, List, Optional, Type, TypeVar, Union, get_type_hints
+from typing import Any, ContextManager, Dict, Generic, List, Optional, Type, TypeVar, Union, get_type_hints
 
 T = TypeVar("T")
 MISSING: Any = "???"
@@ -671,28 +672,36 @@ class Coqpit(Serializable, MutableMapping):
         """Returns a JSON string representation."""
         return json.dumps(asdict(self), indent=4, default=_coqpit_json_default)
 
-    def save_json(self, file_name: str) -> None:
+    def save_json(self, file_name: Union[str, Path, Any]) -> None:
         """Save Coqpit to a json file.
 
         Args:
-            file_name (str): path to the output json file.
+            file_name (str, Path or file-like object): path to the output json file or a file-like object to write to.
         """
-        with open(file_name, "w", encoding="utf8") as f:
+        if isinstance(file_name, (Path, str)):
+            opened = open(file_name, "w", encoding="utf8")
+        else:
+            opened = contextlib.contextmanager(lambda: (yield file_name))()
+        with opened as f:
             json.dump(asdict(self), f, indent=4)
 
-    def load_json(self, file_name: str) -> None:
+    def load_json(self, file_name: Union[str, Path, Any]) -> None:
         """Load a json file and update matching config fields with type checking.
         Non-matching parameters in the json file are ignored.
 
         Args:
-            file_name (str): path to the json file.
+            file_name (str, Path or file-like object): Path to the json file or a file-like object to read from.
 
         Returns:
             Coqpit: new Coqpit with updated config fields.
         """
-        with open(file_name, "r", encoding="utf8") as f:
-            input_str = f.read()
-            dump_dict = json.loads(input_str)
+        opened: ContextManager
+        if isinstance(file_name, (Path, str)):
+            opened = open(file_name, "r", encoding="utf8")
+        else:
+            opened = contextlib.contextmanager(lambda: (yield file_name))()
+        with opened as f:
+            dump_dict = json.load(f)
         # TODO: this looks stupid 💆
         self = self.deserialize(dump_dict)  # pylint: disable=self-cls-assignment
         self.check_values()

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -31,6 +31,18 @@ class Reference(Coqpit):
     )
 
 
+def assert_equal(a: Reference, b: Group):
+    assert len(a) == len(b)
+    assert a.name == b.name
+    assert a.size == b.size
+    assert a.people[0].name == b.people[0].name
+    assert a.people[1].name == b.people[1].name
+    assert a.people[2].name == b.people[2].name
+    assert a.people[0].age == b.people[0].age
+    assert a.people[1].age == b.people[1].age
+    assert a.people[2].age == b.people[2].age
+
+
 def test_serizalization():
     file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_serialization.json")
 
@@ -41,13 +53,20 @@ def test_serizalization():
     new_config.load_json(file_path)
     new_config.pprint()
 
-    # check values
-    assert len(ref_config) == len(new_config)
-    assert ref_config.name == new_config.name
-    assert ref_config.size == new_config.size
-    assert ref_config.people[0].name == new_config.people[0].name
-    assert ref_config.people[1].name == new_config.people[1].name
-    assert ref_config.people[2].name == new_config.people[2].name
-    assert ref_config.people[0].age == new_config.people[0].age
-    assert ref_config.people[1].age == new_config.people[1].age
-    assert ref_config.people[2].age == new_config.people[2].age
+    assert_equal(ref_config, new_config)
+
+
+def test_serizalization_fileobject():
+    """Test serialization to and from file-like objects instead of paths"""
+    file_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "test_serialization_file.json")
+
+    ref_config = Reference()
+    with open(file_path, "w", encoding="utf-8") as f:
+        ref_config.save_json(f)
+
+    new_config = Group()
+    with open(file_path, "r", encoding="utf-8") as f:
+        new_config.load_json(f)
+    new_config.pprint()
+
+    assert_equal(ref_config, new_config)


### PR DESCRIPTION
Replaces #15 which was reverted. Fixes the incompatibility with python 3.6 by using a regular contextmanager instead of nullcontext.